### PR TITLE
Fixing Compiler Errors

### DIFF
--- a/WindowsLib/RichEditControl.cpp
+++ b/WindowsLib/RichEditControl.cpp
@@ -26,7 +26,7 @@ namespace WinLib {
         setTextSettings.codepage = 1200;
 #else
         setTextSettings.flags = ST_NEWCHARS;
-        setTextSettings.codepage = CP_ASP;
+        setTextSettings.codepage = CP_ACP;
 #endif
     }
 
@@ -48,7 +48,7 @@ namespace WinLib {
         if ( scrollable )
             dwStyle |= ES_AUTOVSCROLL|ES_AUTOHSCROLL|WS_VSCROLL|WS_HSCROLL;
 
-        return WindowControl::CreateControl( WS_EX_CLIENTEDGE, MSFTEDIT_CLASS, "", dwStyle,
+        return WindowControl::CreateControl( WS_EX_CLIENTEDGE, RICHEDIT_CLASS, "", dwStyle,
                                              x, y, width, height,
                                              hParent, (HMENU)id, true );
     }

--- a/WindowsLib/WindowMenu.cpp
+++ b/WindowsLib/WindowMenu.cpp
@@ -36,7 +36,7 @@ namespace WinLib {
         {
             auto uiText = icux::toUistring(text);
             menuItemInfo.fMask = MIIM_STRING;
-            menuItemInfo.dwTypeData = (LPWSTR)uiText.c_str();
+            WideCharToMultiByte(CP_ACP, 0, (LPWSTR)uiText.c_str(), -1, menuItemInfo.dwTypeData, NULL, NULL, NULL);
             SetMenuItemInfo(hMenu, itemId, FALSE, &menuItemInfo);
         }
         


### PR DESCRIPTION
Fixed a typo, changed MSFTEDIT_Class to be RICHEDIT_CLASS instead, and implemented a WideCharToMultiByte to convert LPWSTR to LPSTR.