### PR TITLE
Fix Compression Parameter Error

### DIFF
--- a/MappingCoreLib/MpqFile.cpp
+++ b/MappingCoreLib/MpqFile.cpp
@@ -195,7 +195,7 @@ std::optional<std::vector<u8>> MpqFile::getFile(const std::string & mpqPath) con
             auto fileData = std::make_optional<std::vector<u8>>(fileSize);
             bool success = SFileReadFile(openFile, (LPVOID)&fileData.value()[0], (DWORD)fileSize, (LPDWORD)(&bytesRead), NULL);
             SFileCloseFile(openFile);
-            return fileData;
+            return success ? fileData : std::nullopt;
         }
     }
     return std::nullopt;
@@ -258,7 +258,9 @@ bool MpqFile::addFile(const std::string & mpqPath, const std::vector<u8> & fileD
         HANDLE hFile = NULL;
         if ( SFileCreateFile(hMpq, mpqPath.c_str(), 0, (DWORD)fileData.size(), 0, MPQ_FILE_COMPRESS | MPQ_FILE_REPLACEEXISTING, &hFile) )
         {
-            addedFile = SFileWriteFile(hFile, &fileData[0], (DWORD)fileData.size(), (DWORD)wavQuality);
+            DWORD compression = wavQuality == MPQ_WAVE_QUALITY_LOW || wavQuality == MPQ_WAVE_QUALITY_MEDIUM ?
+                (MPQ_COMPRESSION_ADPCM_STEREO | MPQ_COMPRESSION_HUFFMANN) : MPQ_COMPRESSION_PKWARE;
+            addedFile = SFileWriteFile(hFile, &fileData[0], (DWORD)fileData.size(), compression);
             SFileFinishFile(hFile);
         }
 


### PR DESCRIPTION
Fix error that could sometimes cause invalid MPQs to be written due to invalid compression parameters. Also fix a separate bug that caused Chkdraft to try to read a file from an MPQ even if it was invalid.