### PR TITLE
Misc Fixes

### DIFF
--- a/ChkdraftLib/Mapping/Selections.cpp
+++ b/ChkdraftLib/Mapping/Selections.cpp
@@ -265,6 +265,23 @@ void Selections::selectLocation(s32 clickX, s32 clickY, bool canSelectAnywhere)
     }
 }
 
+bool Selections::selFlagsIndicateInside() const
+{
+    switch ( locSelFlags )
+    {
+        case LocSelFlags::West:
+        case LocSelFlags::North:
+        case LocSelFlags::East:
+        case LocSelFlags::South:
+        case LocSelFlags::NorthWest:
+        case LocSelFlags::NorthEast:
+        case LocSelFlags::SouthEast:
+        case LocSelFlags::SouthWest:
+        case LocSelFlags::Middle: return true;
+        default: return false;
+    }
+}
+
 void Selections::addUnit(u16 index)
 {
     if ( !unitIsSelected(index) )

--- a/ChkdraftLib/Mapping/Selections.h
+++ b/ChkdraftLib/Mapping/Selections.h
@@ -62,6 +62,7 @@ class Selections
         void selectLocation(s32 clickX, s32 clickY, bool canSelectAnywhere); // Based on map click
         void setLocationFlags(LocSelFlags flags) { locSelFlags = flags; }
         LocSelFlags getLocationFlags() { return locSelFlags; }
+        bool selFlagsIndicateInside() const;
         
         void addUnit(u16 index);
         void removeUnit(u16 index);

--- a/ChkdraftLib/Windows/DialogWindows/TrigEditor/Switches.cpp
+++ b/ChkdraftLib/Windows/DialogWindows/TrigEditor/Switches.cpp
@@ -61,8 +61,9 @@ void SwitchesWindow::RefreshWindow()
             chkd.trigEditorWindow.SetWinText("Trigger Editor - [Switch " + std::to_string(selectedSwitch + 1) + "]");
 
             EnableEditing();
-            size_t switchNameStringId = CM->getSwitchNameStringId(selectedSwitch);
-            bool hasName = switchNameStringId != Chk::StringId::NoString;
+            size_t switchNameStringId = CM->getSwitchNameStringId(selectedSwitch, Chk::Scope::Game);
+            size_t editorSwitchNameStringId = CM->getSwitchNameStringId(selectedSwitch, Chk::Scope::Editor);
+            bool hasName = switchNameStringId != Chk::StringId::NoString || editorSwitchNameStringId != Chk::StringId::NoString;
             bool isExtendedString = false;
 
             checkUseDefaultName.SetCheck(!hasName);

--- a/ChkdraftLib/Windows/DialogWindows/TrigModify/TrigActions.cpp
+++ b/ChkdraftLib/Windows/DialogWindows/TrigModify/TrigActions.cpp
@@ -404,7 +404,7 @@ void TrigActionsWindow::UpdateActionArg(u8 actionNum, u8 argNum, const std::stri
         bool madeChange = false;
         if ( argType == Chk::Action::ArgType::String || argType == Chk::Action::ArgType::Sound )
         {
-            size_t newStringId = CM->findString<SingleLineChkdString>(chkdSuggestText);
+            size_t newStringId = CM->findString<SingleLineChkdString>(newText);
             if ( newStringId == Chk::StringId::NoString )
                 newStringId = CM->findString<SingleLineChkdString>(chkdSuggestText);
 

--- a/ChkdraftLib/Windows/MainWindows/LeftBar.cpp
+++ b/ChkdraftLib/Windows/MainWindows/LeftBar.cpp
@@ -226,6 +226,13 @@ LRESULT LeftBar::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             }
             break;
 
+        case WM_MOUSEWHEEL:
+            if ( CM != nullptr && chkd.maps.clipboard.isPasting() )
+                SendMessage(CM->getHandle(), WM_MOUSEWHEEL, wParam, lParam);
+            else
+                return ClassWindow::WndProc(hWnd, msg, wParam, lParam);
+            break;
+
         default:
             return ClassWindow::WndProc(hWnd, msg, wParam, lParam);
             break;

--- a/ChkdraftLib/Windows/MainWindows/Maps.cpp
+++ b/ChkdraftLib/Windows/MainWindows/Maps.cpp
@@ -742,7 +742,7 @@ void Maps::updateCursor(s32 xc, s32 yc)
     if ( currentlyActiveMap->getLayer() == Layer::Locations )
     {
         u16 selectedLocation = selections.getSelectedLocation();
-        if ( selectedLocation != NO_LOCATION && selectedLocation < currentlyActiveMap->numUnits() )
+        if ( selectedLocation != NO_LOCATION && selectedLocation < currentlyActiveMap->numLocations() )
         {
             const Chk::Location & loc = currentlyActiveMap->getLocation(selectedLocation);
             s32 locationLeft = std::min(loc.left, loc.right),
@@ -755,7 +755,7 @@ void Maps::updateCursor(s32 xc, s32 yc)
                 bottomOuterBound = locationBottom+5;
 
             if ( xc >= leftOuterBound && xc <= rightOuterBound &&
-                    yc >= topOuterBound && yc <= bottomOuterBound    )
+                 yc >= topOuterBound && yc <= bottomOuterBound )
             {
                 s32 locationWidth = locationRight-locationLeft,
                     locationHeight = locationBottom-locationTop,
@@ -774,7 +774,7 @@ void Maps::updateCursor(s32 xc, s32 yc)
                     bottomInnerBound = locationBottom-5;
 
                 if ( xc >= leftInnerBound && xc <= rightInnerBound &&
-                        yc >= topInnerBound && yc <= bottomInnerBound    )
+                     yc >= topInnerBound && yc <= bottomInnerBound )
                 {
                     currCursor = &sizeAllCursor;
                     SetCursor(sizeAllCursor);
@@ -790,7 +790,7 @@ void Maps::updateCursor(s32 xc, s32 yc)
                     SetCursor(weCursor);
                 } // Invariant: is on a corner
                 else if ( ( xc < leftInnerBound && yc < topInnerBound ) ||
-                            ( xc > rightInnerBound && yc > bottomInnerBound ) )
+                          ( xc > rightInnerBound && yc > bottomInnerBound ) )
                 {
                     currCursor = &nwseCursor;
                     SetCursor(nwseCursor);

--- a/ChkdraftLib/Windows/MainWindows/MiniMap.cpp
+++ b/ChkdraftLib/Windows/MainWindows/MiniMap.cpp
@@ -67,18 +67,27 @@ LRESULT MiniMap::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
     switch ( msg )
     {
         case WM_LBUTTONDOWN:
-            MiniMapClick(lParam);
-            UnlockCursor();
-            LockCursor();
+            if ( !cursorLocked )
+            {
+                cursorLocked = true;
+                MiniMapClick(lParam);
+                LockCursor();
+            }
             break;
 
         case WM_LBUTTONUP:
             ClipCursor(NULL);
+            cursorLocked = false;
             break;
 
         case WM_MOUSEMOVE:
             if ( wParam == MK_LBUTTON )
                 MiniMapClick(lParam);
+            else if ( !cursorLocked )
+            {
+                UnlockCursor();
+                cursorLocked = false;
+            }
             break;
 
         case WM_PAINT:

--- a/ChkdraftLib/Windows/MainWindows/MiniMap.h
+++ b/ChkdraftLib/Windows/MainWindows/MiniMap.h
@@ -12,6 +12,9 @@ class MiniMap : public WinLib::ClassWindow
     protected:
         void MiniMapClick(LPARAM ClickPoints);
         LRESULT WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+    private:
+        bool cursorLocked = false;
 };
 
 #endif

--- a/MappingCoreLib/MapFile.cpp
+++ b/MappingCoreLib/MapFile.cpp
@@ -311,6 +311,8 @@ bool MapFile::openMapFile(const std::string & filePath)
             }
             else if ( ::lastErrorIndicatedFileNotFound() )
                 CHKD_ERR("File Not Found");
+            else if ( ::lastErrorIndicatedBadFormat() )
+                CHKD_ERR("Selected file was not a valid MPQ");
             else
                 CHKD_ERR("%d", ::getLastError());
         }

--- a/MappingCoreLib/Scenario.cpp
+++ b/MappingCoreLib/Scenario.cpp
@@ -6660,6 +6660,7 @@ Chk::ExtendedTrigData & Scenario::getTriggerExtension(size_t triggerIndex, bool 
             if ( (i & Chk::UnusedExtendedTrigDataIndexCheck) != 0 && usedExtensionIndexes.count(u32(i)) == 0 ) // If index is usable and unused
             {
                 this->triggerExtensions[i] = Chk::ExtendedTrigData{};
+                trigger.setExtendedDataIndex(this->triggerExtensions.size()-1);
                 return this->triggerExtensions[i];
             }
         }

--- a/MappingCoreLib/SystemIO.cpp
+++ b/MappingCoreLib/SystemIO.cpp
@@ -626,6 +626,15 @@ bool lastErrorIndicatedFileNotFound()
 #endif;
 }
 
+bool lastErrorIndicatedBadFormat()
+{
+#ifdef _WIN32
+    return ::GetLastError() == ERROR_BAD_FORMAT;
+#else
+    return false;
+#endif;
+}
+
 unsigned long getLastError()
 {
 #ifdef _WIN32

--- a/MappingCoreLib/SystemIO.h
+++ b/MappingCoreLib/SystemIO.h
@@ -74,6 +74,8 @@ bool browseForSave(std::string & filePath, u32 & filterIndex, const std::vector<
 
 bool lastErrorIndicatedFileNotFound();
 
+bool lastErrorIndicatedBadFormat();
+
 unsigned long getLastError();
 
 #endif

--- a/WindowsLib/ContextMenu.h
+++ b/WindowsLib/ContextMenu.h
@@ -2,6 +2,7 @@
 #define CONTEXTMENU_H
 #include <Windows.h>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 #include "../CrossCutLib/SimpleIcu.h"


### PR DESCRIPTION
- Fix missing header on vs2022
- Properly indicate the error in the log for invalid MPQ files
- Fix issue where trigger extended dat indexes were not properly set
- Fix cursor locked in minimap issue
- Fix missing location resize/move indicators
- Fix zoom while pasting issue
- Double click acts as a return key press (opens properties)
- Disallow zero-sized location creation (though not resizing to zero)
- Fix copy-paste trigger strings issue
- Fix whether switch indicates it has a name
- Deselect a location when clicking outside it