### PR TITLE
Ctrl+Select QuickTile, Unit/Sprite Centering, Misc Fixes

### DIFF
--- a/src/chkdraft/common_files/version.h
+++ b/src/chkdraft/common_files/version.h
@@ -8,7 +8,7 @@ using u16 = uint16_t;
 constexpr u16 MajorVersionNumber = 1;
 
 // Minor version is a 2-digit base-10 number
-constexpr u16 MinorVersionNumber = 8;
+constexpr u16 MinorVersionNumber = 10;
 
 u16 GetDateShort(); // Returns 384*(year-2000) + 32*month + day based on the date compiled
 

--- a/src/chkdraft/mapping/clipboard.cpp
+++ b/src/chkdraft/mapping/clipboard.cpp
@@ -777,8 +777,10 @@ void Clipboard::copy(GuiMap & map, Layer layer)
         middle.y = edges.top+(edges.bottom-edges.top)/2;
         if ( hasTiles() || hasDoodads() || hasFogTiles() )
         {
-            middle.x = (middle.x+16)/32*32;
-            middle.y = (middle.y+16)/32*32;
+            bool evenTileWidth = (edges.right-edges.left)/32%2 == 0;
+            bool evenTileHeight = (edges.bottom-edges.top)/32%2 == 0;
+            middle.x = (middle.x+16)/32*32-(evenTileWidth ? 0 : 16);
+            middle.y = (middle.y+16)/32*32-(evenTileHeight ? 0 : 16);
         }
         return middle;
     };
@@ -852,6 +854,12 @@ void Clipboard::setQuickDoodad(u16 doodadStartTileGroup)
     prevPaste.y = -1;
     quickPaste = true;
     pasting = true;
+}
+
+void Clipboard::setQuickTile(u16 index, s32 xc, s32 yc)
+{
+    quickTiles.clear();
+    quickTiles.push_back(PasteTileNode(index, xc, yc, TileNeighbor::All));
 }
 
 void Clipboard::addQuickTile(u16 index, s32 xc, s32 yc)

--- a/src/chkdraft/mapping/clipboard.h
+++ b/src/chkdraft/mapping/clipboard.h
@@ -143,6 +143,7 @@ public:
     void setQuickIsom(size_t terrainTypeIndex);
     void setQuickDoodad(u16 doodadStartTileGroup);
         
+    void setQuickTile(u16 index, s32 xc, s32 yc);
     void addQuickTile(u16 index, s32 xc, s32 yc);
     bool hasQuickTiles() { return quickTiles.size() > 0; }
 

--- a/src/chkdraft/mapping/sc_graphics.cpp
+++ b/src/chkdraft/mapping/sc_graphics.cpp
@@ -2048,20 +2048,24 @@ void DrawPasteGraphics(const WinLib::DeviceContext & dc, ChkdPalette & palette, 
         dc.setBitsToDevice(0, 0, width, height, 0, 0, 0, height, &graphicBits[0], &bmi);
     };
 
+    auto graphicalEndDrag = selections.endDrag;
+    if ( graphicalEndDrag.x == -1 && graphicalEndDrag.y == -1 )
+        graphicalEndDrag = map.getLastMousePosition();
+
     if ( layer == Layer::Terrain )
-        drawPasteTerrain(selections.endDrag);
+        drawPasteTerrain(graphicalEndDrag);
     else if ( layer == Layer::Doodads )
-        drawPasteDoodads(selections.endDrag);
+        drawPasteDoodads(graphicalEndDrag);
     else if ( layer == Layer::Units )
-        drawPasteUnits(selections.endDrag);
+        drawPasteUnits(graphicalEndDrag);
     else if ( layer == Layer::Sprites )
-        drawPasteSprites(selections.endDrag);
+        drawPasteSprites(graphicalEndDrag);
     else if ( layer == Layer::FogEdit )
     {
         const auto brushWidth = clipboard.getFogBrush().width;
         const auto brushHeight = clipboard.getFogBrush().height;
-        s32 hoverTileX = (selections.endDrag.x + (brushWidth % 2 == 0 ? 16 : 0))/32;
-        s32 hoverTileY = (selections.endDrag.y + (brushHeight % 2 == 0 ? 16 : 0))/32;
+        s32 hoverTileX = (graphicalEndDrag.x + (brushWidth % 2 == 0 ? 16 : 0))/32;
+        s32 hoverTileY = (graphicalEndDrag.y + (brushHeight % 2 == 0 ? 16 : 0))/32;
 
         const auto startX = 32*(hoverTileX - brushWidth/2) - screenLeft;
         const auto startY = 32*(hoverTileY - brushHeight/2) - screenTop;
@@ -2077,7 +2081,7 @@ void DrawPasteGraphics(const WinLib::DeviceContext & dc, ChkdPalette & palette, 
     }
     else if ( layer == Layer::CutCopyPaste )
     {
-        point paste = selections.endDrag;
+        point paste = graphicalEndDrag;
         bool pastingTerrain = map.getCutCopyPasteTerrain() && clipboard.hasTiles();
         bool pastingDoodads = map.getCutCopyPasteDoodads() && clipboard.hasDoodads();
         bool pastingFog = map.getCutCopyPasteFog() && clipboard.hasFogTiles();

--- a/src/chkdraft/mapping/scr_graphics.cpp
+++ b/src/chkdraft/mapping/scr_graphics.cpp
@@ -2135,6 +2135,9 @@ void Scr::MapGraphics::drawTileOverlays()
 
 void Scr::MapGraphics::drawTileVertices(Scr::Grp & tilesetGrp, s32 width, s32 height, const glm::mat4x4 & positionTransformation, bool isBaseTerrain)
 {
+    if ( tileVertices.vertices.empty() )
+        return;
+
     auto tilesetIndex = Sc::Terrain::Tileset(map.getTileset() % Sc::Terrain::NumTilesets);
     bool drawHdWater = loadSettings.visualQuality > VisualQuality::SD && isBaseTerrain &&
         (tilesetIndex == Sc::Terrain::Tileset::Badlands || tilesetIndex == Sc::Terrain::Tileset::Jungle ||

--- a/src/chkdraft/mapping/wgl_render_context.h
+++ b/src/chkdraft/mapping/wgl_render_context.h
@@ -88,4 +88,15 @@ public:
             gl::ContextSemaphore::claimContext();
     }
 
+    void releaseDeviceContext(std::shared_ptr<WinLib::DeviceContext> & deviceContext)
+    {
+        if ( deviceContext.get() == this->deviceContext.get() )
+        {
+            if ( deviceContextUsed )
+                gl::ContextSemaphore::releaseContext();
+            
+            this->deviceContext = nullptr;
+        }
+    }
+
 };

--- a/src/chkdraft/ui/dialog_windows/layers/sprite_properties/sprite_properties.cpp
+++ b/src/chkdraft/ui/dialog_windows/layers/sprite_properties/sprite_properties.cpp
@@ -516,7 +516,7 @@ void SpritePropertiesWindow::LvItemChanged(NMHDR* nmhdr)
             WindowsItem::SetWinText(spriteName);
             SetSpriteFieldText(sprite);
 
-            CM->Redraw(false);
+            CM->viewSprite(index);
         }
         else if ( itemInfo->uOldState & LVIS_SELECTED ) // From selected to not selected
                                                         // Remove item from selection
@@ -534,7 +534,10 @@ void SpritePropertiesWindow::LvItemChanged(NMHDR* nmhdr)
                 DisableSpriteEditing();
             }
 
-            CM->Redraw(false);
+            if ( selections.hasSprites() )
+                CM->viewSprite(selections.getFirstSprite());
+            else
+                CM->Redraw(false);
         }
     }
 }

--- a/src/chkdraft/ui/dialog_windows/layers/terrain_palette.cpp
+++ b/src/chkdraft/ui/dialog_windows/layers/terrain_palette.cpp
@@ -4,7 +4,7 @@
 #include <WindowsX.h>
 
 #define START_TILES_YC 0
-#define NUM_TILES 26640
+#define NUM_TILES 32752
 #define TILES_PER_ROW 16
 #define PIXELS_PER_TILE 33
 #define PIXELS_PER_WHEEL 32
@@ -33,6 +33,41 @@ bool TerrainPaletteWindow::DestroyThis()
         this->openGlDc = nullptr;
     }
     return ClassDialog::DestroyDialog();
+}
+
+void TerrainPaletteWindow::SelectTile(std::uint16_t tileValue)
+{
+    u32 newTileRow = u32(tileValue)/TILES_PER_ROW;
+    int newTileOffsetY = newTileRow*PIXELS_PER_TILE;
+    int numRows = (WindowsItem::cliHeight()-START_TILES_YC) / PIXELS_PER_TILE;
+    
+    u32 firstRow = tilesetIndexedYC/PIXELS_PER_TILE;
+    int yOffset = tilesetIndexedYC%PIXELS_PER_TILE;
+    u32 lastRow = firstRow+numRows;
+
+    bool redraw = false;
+    if ( newTileRow <= firstRow )
+    {
+        tilesetIndexedYC = newTileRow*PIXELS_PER_TILE;
+        redraw = true;
+    }
+    else if ( newTileRow >= lastRow )
+    {
+        tilesetIndexedYC = (newTileRow-numRows)*PIXELS_PER_TILE+(PIXELS_PER_TILE-WindowsItem::cliHeight()%PIXELS_PER_TILE);
+        redraw = true;
+    }
+
+    if ( !chkd.maps.clipboard.hasQuickTiles() || !chkd.maps.clipboard.isPasting() || chkd.maps.clipboard.getTiles()[0].value != tileValue )
+    {
+        chkd.maps.clipboard.endPasting();
+        CM->setSubLayer(TerrainSubLayer::Rectangular);
+        chkd.maps.clipboard.setQuickTile(tileValue, -16, -16);
+        chkd.maps.startPaste(true);
+        redraw = true;
+    }
+
+    if ( redraw )
+        WindowsItem::RedrawThis();
 }
 
 void TerrainPaletteWindow::Activate(WPARAM wParam)

--- a/src/chkdraft/ui/dialog_windows/layers/terrain_palette.cpp
+++ b/src/chkdraft/ui/dialog_windows/layers/terrain_palette.cpp
@@ -27,7 +27,11 @@ bool TerrainPaletteWindow::CreateThis(HWND hParent)
 
 bool TerrainPaletteWindow::DestroyThis()
 {
-    this->openGlDc = nullptr;
+    if ( this->openGlDc != nullptr )
+    {
+        chkd.maps.releaseRenderContext(this->openGlDc);
+        this->openGlDc = nullptr;
+    }
     return ClassDialog::DestroyDialog();
 }
 
@@ -278,8 +282,7 @@ BOOL TerrainPaletteWindow::DlgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lP
         case WM_PAINT: DoPaint(); break;
         case WM_MOUSEWHEEL: MouseWheel(wParam); break;
         case WM_GETMINMAXINFO: GetMinMaxInfo(lParam); break;
-        case WM_CLOSE: ClassDialog::DestroyDialog(); break;
-        case WM_DESTROY: ClassDialog::DestroyDialog(); break;
+        case WM_CLOSE: DestroyThis(); return TRUE; break;
         default: return ClassDialog::DlgProc(hWnd, msg, wParam, lParam); break;
     }
     return 0;

--- a/src/chkdraft/ui/dialog_windows/layers/terrain_palette.h
+++ b/src/chkdraft/ui/dialog_windows/layers/terrain_palette.h
@@ -12,6 +12,7 @@ class TerrainPaletteWindow : public WinLib::ClassDialog
         bool CreateThis(HWND hParent);
         bool DestroyThis();
         void SetTileDialog(HWND hWnd);
+        void SelectTile(std::uint16_t tileValue);
 
     protected:
         void Activate(WPARAM wParam);

--- a/src/chkdraft/ui/dialog_windows/layers/unit_properties/unit_properties.cpp
+++ b/src/chkdraft/ui/dialog_windows/layers/unit_properties/unit_properties.cpp
@@ -791,7 +791,7 @@ void UnitPropertiesWindow::LvItemChanged(NMHDR* nmhdr)
             WindowsItem::SetWinText(*unitName);
             SetUnitFieldText(unit);
 
-            CM->Redraw(false);
+            CM->viewUnit(index);
         }
         else if ( itemInfo->uOldState & LVIS_SELECTED ) // From selected to not selected
                                                         // Remove item from selection
@@ -816,7 +816,10 @@ void UnitPropertiesWindow::LvItemChanged(NMHDR* nmhdr)
                 DisableUnitEditing();
             }
 
-            CM->Redraw(false);
+            if ( selections.hasUnits() )
+                CM->viewUnit(selections.getFirstUnit());
+            else
+                CM->Redraw(false);
         }
     }
 }

--- a/src/chkdraft/ui/main_windows/gui_map.h
+++ b/src/chkdraft/ui/main_windows/gui_map.h
@@ -89,6 +89,7 @@ class GuiMap : public MapFile, public WinLib::ClassWindow, public IObserveUndos,
                     void createMobileInvertedLocation();
 
                     void viewUnit(u16 unitIndex);
+                    void viewSprite(u16 spriteIndex);
                     void viewLocation(u16 locationId);
                     LocSelFlags getLocSelFlags(s32 xc, s32 yc);
                     bool moveLocation(u32 downX, u32 downY, u32 upX, u32 upY);
@@ -228,6 +229,8 @@ class GuiMap : public MapFile, public WinLib::ClassWindow, public IObserveUndos,
                     GuiMap::Skin GetSkin();
                     void SetSkin(GuiMap::Skin skin);
 
+                    point getLastMousePosition() { return lastMousePosition; }
+
 
     protected:
 
@@ -322,6 +325,7 @@ class GuiMap : public MapFile, public WinLib::ClassWindow, public IObserveUndos,
                     int panCurrentY = 0;
 
                     ChkdBitmap graphicBits {};
+                    point lastMousePosition {};
                     s32 screenLeft = 0;
                     s32 screenTop = 0;
                     u32 bitmapWidth = 0;

--- a/src/chkdraft/ui/main_windows/maps.cpp
+++ b/src/chkdraft/ui/main_windows/maps.cpp
@@ -810,6 +810,12 @@ void Maps::updateCursor(s32 xc, s32 yc)
         SetCursor(standardCursor);
 }
 
+void Maps::releaseRenderContext(std::shared_ptr<WinLib::DeviceContext> & deviceContext)
+{
+    if ( openGlRenderContext && deviceContext != nullptr )
+        openGlRenderContext->releaseDeviceContext(deviceContext);
+}
+
 void Maps::setGlRenderTarget(std::shared_ptr<WinLib::DeviceContext> & deviceContext, WinLib::WindowsItem & windowsItem)
 {
     if ( !deviceContext )

--- a/src/chkdraft/ui/main_windows/maps.h
+++ b/src/chkdraft/ui/main_windows/maps.h
@@ -57,6 +57,7 @@ class Maps : public WinLib::MdiClient
         void stickCursor(); // Ensures that the cursor does revert during click & drags
         void updateCursor(s32 xc, s32 yc);
 
+        void releaseRenderContext(std::shared_ptr<WinLib::DeviceContext> & deviceContext);
         // If not created, creates the rendering context with the given device context (which is also created if null); targets the given/new device context
         void setGlRenderTarget(std::shared_ptr<WinLib::DeviceContext> & deviceContext, WinLib::WindowsItem & windowsItem);
         gl::ContextSemaphore* getContextSemaphore();

--- a/src/mapping_core/scenario.cpp
+++ b/src/mapping_core/scenario.cpp
@@ -3660,7 +3660,7 @@ u16 Scenario::getTile(size_t tileXc, size_t tileYc, Chk::Scope scope) const
     return 0;
 }
 
-inline u16 Scenario::getTilePx(size_t pixelXc, size_t pixelYc, Chk::Scope scope) const
+u16 Scenario::getTilePx(size_t pixelXc, size_t pixelYc, Chk::Scope scope) const
 {
     return getTile(pixelXc / Sc::Terrain::PixelsPerTile, pixelYc / Sc::Terrain::PixelsPerTile, scope);
 }
@@ -3685,7 +3685,7 @@ void Scenario::setTile(size_t tileXc, size_t tileYc, u16 tileValue, Chk::Scope s
     }
 }
 
-inline void Scenario::setTilePx(size_t pixelXc, size_t pixelYc, u16 tileValue, Chk::Scope scope)
+void Scenario::setTilePx(size_t pixelXc, size_t pixelYc, u16 tileValue, Chk::Scope scope)
 {
     setTile(pixelXc / Sc::Terrain::PixelsPerTile, pixelYc / Sc::Terrain::PixelsPerTile, tileValue, scope);
 }

--- a/src/mapping_core/scenario.h
+++ b/src/mapping_core/scenario.h
@@ -272,9 +272,9 @@ struct Scenario
     void setDimensions(u16 newTileWidth, u16 newTileHeight, u16 sizeValidationFlags = SizeValidationFlag::Default, s32 leftEdge = 0, s32 topEdge = 0);
 
     u16 getTile(size_t tileXc, size_t tileYc, Chk::Scope scope = Chk::Scope::Game) const;
-    inline u16 getTilePx(size_t pixelXc, size_t pixelYc, Chk::Scope scope = Chk::Scope::Game) const;
+    u16 getTilePx(size_t pixelXc, size_t pixelYc, Chk::Scope scope = Chk::Scope::Game) const;
     void setTile(size_t tileXc, size_t tileYc, u16 tileValue, Chk::Scope scope = Chk::Scope::Game);
-    inline void setTilePx(size_t pixelXc, size_t pixelYc, u16 tileValue, Chk::Scope scope = Chk::Scope::Game);
+    void setTilePx(size_t pixelXc, size_t pixelYc, u16 tileValue, Chk::Scope scope = Chk::Scope::Game);
         
     Chk::IsomRect & getIsomRect(size_t isomRectIndex);
     const Chk::IsomRect & getIsomRect(size_t isomRectIndex) const;


### PR DESCRIPTION
- Enable selecting quick tiles while tileset indexed is open with ctrl+click
- Fix offset for odd-sized tile paste (e.g. singular tile paste) GDI graphics
- Fix offset for tile display with ctrl+click+mousemove
- Fix linker error for getTilePx/setTilePx
- Extend tileset indexed palette to include all remastered tiles
- Jump to focused/selected unit/sprite from unit/sprite list on the map
- Bump version to 10 (should have been bumped to 9 previously)