### PR TITLE
Sound Button Fixes & Gfx Utils Touchups

### DIFF
--- a/src/chkdraft/ui/dialog_windows/map_settings/sound_editor.cpp
+++ b/src/chkdraft/ui/dialog_windows/map_settings/sound_editor.cpp
@@ -485,15 +485,17 @@ void SoundEditorWindow::MapSoundSelectionChanged()
     else
     {
         buttonDeleteSound.EnableThis();
-        LPARAM soundStringId = 0;
         if ( selectedSoundEntry >= 0 && selectedSoundEntry < soundEntries.size() )
         {
-            if ( !CM->stringIsSound(size_t(soundEntries[selectedSoundEntry].stringId)) )
-                buttonDeleteSound.DisableThis();
-
-            SoundStatus soundStatus = CM->getSoundStatus(size_t(soundStringId));
+            SoundStatus soundStatus = CM->getSoundStatus(size_t(soundEntries[selectedSoundEntry].stringId));
             if ( soundStatus == SoundStatus::PendingMatch || soundStatus == SoundStatus::CurrentMatch || soundStatus == SoundStatus::VirtualFile )
                 buttonExtractSound.EnableThis();
+            
+            if ( !CM->stringIsSound(size_t(soundEntries[selectedSoundEntry].stringId)) &&
+                soundStatus != SoundStatus::PendingMatch && soundStatus != SoundStatus::CurrentMatch )
+            {
+                buttonDeleteSound.DisableThis();
+            }
         }
         buttonPlaySound.EnableThis();
     }

--- a/src/map_gfx_utils/map_timings.h
+++ b/src/map_gfx_utils/map_timings.h
@@ -14,6 +14,7 @@ struct MapTimings
     int animRealTimeMs = 0;
     int animGameTimeMs = 0;
     int animTicks = 0;
+    int renderTimeMs = 0;
     int encodeTimeMs = 0; // Time for WebPEncodeLosslessRGB https://developers.google.com/speed/webp/docs/api , usually dwarves other times
     int outFileTimeMs = 0; // Time to write to disk
 
@@ -28,6 +29,7 @@ struct MapTimings
         animRealTimeMs(animSimTimes.realTimeSpentMs),
         animGameTimeMs(animSimTimes.gameTimeSimulatedMs),
         animTicks(animSimTimes.ticks),
+        renderTimeMs(saveWebpResult ? saveWebpResult->renderTimeMs : -1),
         encodeTimeMs(saveWebpResult ? saveWebpResult->encodeTimeMs : -1),
         outFileTimeMs(saveWebpResult ? saveWebpResult->outFileTimeMs : -1)
     {}
@@ -37,6 +39,7 @@ struct MapTimings
         os << "Load skin+tileset: " << time.loadSkinAndTilesetTimeMs << "ms\n"
             << "Map load: " << time.mapLoadTimeMs << "ms\n"
             << "Animation: " << time.animRealTimeMs << "ms (simulated " << time.animTicks << " ticks = " << time.animGameTimeMs << "ms of game time)\n"
+            << "Render: " << time.renderTimeMs << "ms\n"
             << "WebPEncodeLosslessRGB: " << time.encodeTimeMs << "ms\n"
             << "File output: " << time.outFileTimeMs << "ms\n"
             << "Total: " << time.totalTimeMs << "ms\n";

--- a/src/map_gfx_utils/renderer.cpp
+++ b/src/map_gfx_utils/renderer.cpp
@@ -138,7 +138,7 @@ std::optional<Renderer::SaveWebpResult> Renderer::saveMapImageAsWebP(ScMap & map
         result.outputFilePath = outputFilePath;
 
     bool success = false;
-    encodeMapImageAsWebP(map, options, [&](EncodedWebP & encodedWebP) {
+    result.renderTimeMs = encodeMapImageAsWebP(map, options, [&](EncodedWebP & encodedWebP) {
 
         result.encodeTimeMs = encodedWebP.encodeTimeMs;
 
@@ -161,9 +161,9 @@ std::optional<Renderer::SaveWebpResult> Renderer::saveMapImageAsWebP(ScMap & map
     return success ? std::optional<SaveWebpResult>(std::move(result)) : std::nullopt;
 }
 
-void Renderer::getMapImageAsWebP(ScMap & map, const Options & options, EncodedWebP & encodedWebP)
+int Renderer::getMapImageAsWebP(ScMap & map, const Options & options, EncodedWebP & encodedWebP)
 {
-    encodeMapImageAsWebP(map, options, [&encodedWebP](EncodedWebP & data) {
+    return encodeMapImageAsWebP(map, options, [&encodedWebP](EncodedWebP & data) {
         encodedWebP.swap(data);
     });
 }

--- a/src/mapping_core/map_file.cpp
+++ b/src/mapping_core/map_file.cpp
@@ -475,7 +475,8 @@ bool MapFile::removeSoundByStringId(size_t soundStringId, bool removeIfUsed)
     if ( soundStringId != Chk::StringId::UnusedSound )
     {
         auto soundString = Scenario::getString<RawString>(soundStringId, Chk::Scope::Game);
-        Scenario::deleteString(soundStringId);
+        Scenario::deleteSoundReferences(soundStringId);
+        Scenario::deleteString(soundStringId, Chk::Scope::Both, true);
         if ( soundString )
             result = MpqAssetManager::removeAsset(*soundString);
     }

--- a/src/mapping_core/opengl/glfw/context.h
+++ b/src/mapping_core/opengl/glfw/context.h
@@ -2,6 +2,7 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <stdexcept>
+#include <string>
 
 namespace glfw
 {
@@ -9,6 +10,10 @@ namespace glfw
     {
         Context()
         {
+            glfwSetErrorCallback([](int errorCode, const char* description) {
+                throw std::runtime_error("A glfw error occured: [" + std::to_string(errorCode) + "] " + description);
+            });
+
             if ( glfwInit() == GLFW_FALSE )
                 throw std::runtime_error("Failed to initialize glfw!");
         }

--- a/src/mapping_core/scenario.h
+++ b/src/mapping_core/scenario.h
@@ -31,6 +31,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
         void remapStringIds(const std::map<u32, u32> & stringIdRemappings);
         void deleteLocation(size_t locationId);
         void deleteString(size_t stringId);
+        void deleteSoundReferences(size_t stringId);
     };
 
     struct EditTrigger : RareEdit::TrackedElement<Chk::Trigger, PATH(root->triggers[0])>
@@ -58,6 +59,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
         void remapStringIds(const std::map<u32, u32>& stringIdRemappings);
         void deleteLocation(size_t locationId);
         void deleteString(size_t stringId);
+        void deleteSoundReferences(size_t stringId);
 
         void alignConditionsTop();
         void alignActionsTop();
@@ -70,6 +72,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
         void toggleDisabled();
         void remapBriefingStringIds(const std::map<u32, u32> & stringIdRemappings);
         void deleteBriefingString(size_t stringId);
+        void deleteBriefingSoundReferences(size_t stringId);
     };
 
     struct EditBriefingTrigger : RareEdit::TrackedElement<Chk::Trigger, PATH(root->briefingTriggers[0])>
@@ -82,6 +85,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
 
         void remapBriefingStringIds(const std::map<u32, u32>& stringIdRemappings);
         void deleteBriefingString(size_t stringId);
+        void deleteBriefingSoundReferences(size_t stringId);
 
         void alignActionsTop();
     };
@@ -486,6 +490,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
     bool stringIsSound(size_t stringId) const;
     size_t getSoundStringId(size_t soundIndex) const;
     void setSoundStringId(size_t soundIndex, size_t soundStringId);
+    void deleteSoundReferences(size_t stringId);
 
     bool triggerSwitchUsed(size_t switchId) const;
     bool triggerLocationUsed(size_t locationId) const;


### PR DESCRIPTION
- Fix extract and delete sound buttons being disabled when they shouldn't be
- Fix delete sound not removing all the references to the sound
- Report the time spent in the renderMap call specifically
- Add a callback for GLFW errors
- Remove unused lambda
- Investigated PlaySound crash, won't fix until working on ogg/flac support as it seems to be a win32 library issue, best solved by replacing the sound library https://github.com/TheNitesWhoSay/Chkdraft/issues/297